### PR TITLE
Format timestamp

### DIFF
--- a/src/components/Room.tsx
+++ b/src/components/Room.tsx
@@ -51,8 +51,7 @@ function Room() {
   useEffect(() => {
     console.log({ timestamp });
     // update the document title, with roomName and timestamp
-    const formattedTimestamp = formatTimestamp(timestamp);
-    document.title = `${formattedTimestamp}-${window.location.href.split("/")[3]}`;
+    document.title = `${formatTimestamp(timestamp)}-${window.location.href.split("/")[3]}`;
   }, [timestamp]);
 
   useEffect(() => {

--- a/src/components/Room.tsx
+++ b/src/components/Room.tsx
@@ -4,13 +4,15 @@ import { ConnectionState } from "./ConnectionState";
 import { ConnectionManager } from "./ConnectionManager";
 import { Timestamp } from "./Timestamp";
 import { TimerForm } from "./TimerForm";
+
 function Room() {
-  const [isConnected, setIsConnected] = useState(socket.connected);
-  const [timestamp, setTimestamp] = useState("0");
-  const [usersInRoom, setUsersInRoom] = useState(0);
+  const [isConnected, setIsConnected] = useState<boolean>(socket.connected);
+  const [timestamp, setTimestamp] = useState<number>(0);
+  const [usersInRoom, setUsersInRoom] = useState<number>(0);
 
   useEffect(() => {
     const roomName = window.location.href.split("/")[3];
+
     function onConnect() {
       socket.emit("join", roomName);
       console.log("join", roomName);
@@ -23,11 +25,13 @@ function Room() {
     }
 
     function onTimerUpdate(value: string) {
-      setTimestamp(value);
+      console.log("timer", value);
+      setTimestamp(parseInt(value));
     }
-    function onUsersInRoom(value: number) {
+
+    function onUsersInRoom(value: string) {
       console.log("usersInRoom", value);
-      setUsersInRoom(value);
+      setUsersInRoom(parseInt(value));
     }
 
     socket.on("connect", onConnect);

--- a/src/components/Room.tsx
+++ b/src/components/Room.tsx
@@ -4,6 +4,7 @@ import { ConnectionState } from "./ConnectionState";
 import { ConnectionManager } from "./ConnectionManager";
 import { Timestamp } from "./Timestamp";
 import { TimerForm } from "./TimerForm";
+import formatTimestamp from "../helpers/formatTimestamp";
 
 function Room() {
   const [isConnected, setIsConnected] = useState<boolean>(socket.connected);
@@ -50,7 +51,8 @@ function Room() {
   useEffect(() => {
     console.log({ timestamp });
     // update the document title, with roomName and timestamp
-    document.title = `${timestamp}-${window.location.href.split("/")[3]}`;
+    const formattedTimestamp = formatTimestamp(timestamp);
+    document.title = `${formattedTimestamp}-${window.location.href.split("/")[3]}`;
   }, [timestamp]);
 
   useEffect(() => {

--- a/src/components/Timestamp.tsx
+++ b/src/components/Timestamp.tsx
@@ -1,8 +1,10 @@
-export function Timestamp({ timestamp }: { timestamp: string }) {
+import formatTimestamp from "../helpers/formatTimestamp";
+
+export function Timestamp({ timestamp }: { timestamp: number }): JSX.Element {
 
   return (
     <div>
-      <h2>{timestamp}</h2>
+      <h2>{formatTimestamp(timestamp)}</h2>
     </div>
   );
 }

--- a/src/helpers/formatTimestamp.ts
+++ b/src/helpers/formatTimestamp.ts
@@ -4,7 +4,6 @@ function formatTimestamp(timeRemaining: number) {
 	const seconds = Math.floor((timeRemaining % 60));
 	const padZeros = (num: number) => num.toString().padStart(2, '0');
 	const timestamp = `${padZeros(hours)}:${padZeros(minutes)}:${padZeros(seconds)}`;
-	console.log(timestamp);
 	return timestamp;
 }
 

--- a/src/helpers/formatTimestamp.ts
+++ b/src/helpers/formatTimestamp.ts
@@ -1,5 +1,12 @@
 function formatTimestamp(timeRemaining: number) {
-	return timeRemaining;
+	const hours = Math.floor((timeRemaining % (60 * 60 * 99)) / (60 * 60));
+	const minutes = Math.floor((timeRemaining % (60 * 60)) / 60);
+	const seconds = Math.floor((timeRemaining % 60));
+	const padZeros = (num: number) => num.toString().padStart(2, '0');
+	const timestamp = `${padZeros(hours)}:${padZeros(minutes)}:${padZeros(seconds)}`;
+	console.log(timestamp);
+	return timestamp;
 }
 
 export default formatTimestamp;
+


### PR DESCRIPTION
Adds a helper function that is used to format time displayed as `HH:MM:SS` in both the room display and in the title bar.

notes: Does not work above 99 hours.
There are no jest tests yet. Waiting on tests from nmpereira/time-share-v2#5
