### PR TITLE
Format timestamps and add tests

### DIFF
--- a/src/helpers/formatTimestamp.test.ts
+++ b/src/helpers/formatTimestamp.test.ts
@@ -1,13 +1,65 @@
 import formatTimestamp from "./formatTimestamp"
 
 describe('formatTimestamp', () => {
+    describe('Given the number of seconds under 3600', () => {
+        it('should return the timestamp in MM:SS', () => {
+            const timeValues: Record<number, string> = {
+                0: "00:00",
+                1: "00:01",
+                9: "00:09",
+                59: "00:59",
+                60: "01:00",
+                599: "09:59",
+                600: "10:00",
+                3599: "59:59",
+            }
 
- describe('Given the number of seconds', () => {
-    it('should return the number of seconds', () => {
-        const seconds = 5
-        const expected = 5
-        const actual = formatTimestamp(seconds)
-        expect(actual).toBe(expected)
+            for (const seconds in timeValues) {
+                const expected = timeValues[seconds]
+                const actual = formatTimestamp(Number(seconds))
+
+                expect(actual).toBe(expected)
+            }
+        })
     })
- })
+
+    describe('Given the number of seconds between 3599 and 360000', () => {
+        it('should return the timestamp in HH:MM:SS', () => {
+            const timeValues: Record<number, string> = {
+                3600: "01:00:00",
+                35999: "09:59:59",
+                36000: "10:00:00",
+                36059: "10:00:59",
+                359999: "99:59:59",
+            }
+
+            for (const seconds in timeValues) {
+                const expected = timeValues[seconds]
+                const actual = formatTimestamp(Number(seconds))
+
+                expect(actual).toBe(expected)
+            }
+        })
+    })
+
+    describe('Given the number of seconds over 359999', () => {
+        it('should return the timestamp in HH:MM:SS with additional "H" as needed', () => {
+            const timeValues: Record<number, string> = {
+                360000: "100:00:00",
+                360059: "100:00:59",
+                360060: "100:01:00",
+                3599999: "999:59:59",
+                3600000: "1000:00:00",
+                35999999: "9999:59:59",
+                36000000: "10000:00:00",
+            }
+
+            for (const seconds in timeValues) {
+                const expected = timeValues[seconds]
+                const actual = formatTimestamp(Number(seconds))
+
+                expect(actual).toBe(expected)
+            }
+        })
+    })
 })

--- a/src/helpers/formatTimestamp.test.ts
+++ b/src/helpers/formatTimestamp.test.ts
@@ -24,7 +24,7 @@ describe('formatTimestamp', () => {
     })
 
     describe('Given the number of seconds between 3599 and 360000', () => {
-        it('should return the timestamp in HH:MM:SS', () => {
+        it('should return the timestamp in "HHHH:MM:SS" padding the zeros at 2 digits', () => {
             const timeValues: Record<number, string> = {
                 3600: "01:00:00",
                 35999: "09:59:59",
@@ -43,7 +43,7 @@ describe('formatTimestamp', () => {
     })
 
     describe('Given the number of seconds over 359999', () => {
-        it('should return the timestamp in HH:MM:SS with additional "H" as needed', () => {
+        it('should return the timestamp in "HHHH:MM:SS" with additional place values as needed', () => {
             const timeValues: Record<number, string> = {
                 360000: "100:00:00",
                 360059: "100:00:59",

--- a/src/helpers/formatTimestamp.ts
+++ b/src/helpers/formatTimestamp.ts
@@ -5,7 +5,7 @@ function formatTimestamp(timeRemaining: number) {
 	const padZeros = (num: number) => num.toString().padStart(2, '0');
 
 	// Sheds "HH:" when duration is under 1 hour (3600 seconds)
-	if (timeRemaining > 3600) {
+	if (timeRemaining >= 3600) {
 		return `${padZeros(hours)}:${padZeros(minutes)}:${padZeros(seconds)}`;
 	} else {
 		return `${padZeros(minutes)}:${padZeros(seconds)}`

--- a/src/helpers/formatTimestamp.ts
+++ b/src/helpers/formatTimestamp.ts
@@ -1,11 +1,15 @@
 function formatTimestamp(timeRemaining: number) {
-	const hours = Math.floor((timeRemaining % (60 * 60 * 99)) / (60 * 60));
+	const hours = Math.floor(timeRemaining / (60 * 60));
 	const minutes = Math.floor((timeRemaining % (60 * 60)) / 60);
 	const seconds = Math.floor((timeRemaining % 60));
 	const padZeros = (num: number) => num.toString().padStart(2, '0');
-	const timestamp = `${padZeros(hours)}:${padZeros(minutes)}:${padZeros(seconds)}`;
-	return timestamp;
+
+	// Sheds "HH:" when duration is under 1 hour (3600 seconds)
+	if (timeRemaining > 3600) {
+		return `${padZeros(hours)}:${padZeros(minutes)}:${padZeros(seconds)}`;
+	} else {
+		return `${padZeros(minutes)}:${padZeros(seconds)}`
+	}
 }
 
 export default formatTimestamp;
-


### PR DESCRIPTION
## Description
Updated `formatTimestamp` function to support larger values. Also added unit tests for `formatTimestamp`.
Timestamps are displayed in "MM:SS" if under 1 hour and extended to "HHHH:MM:SS" with larger values. 