### PR TITLE
Add vite configs for localhost dns

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,5 +16,6 @@ export default defineConfig({
   server: {
     // this will force the port number to always be 5173
     strictPort: true,
+    port: 5100,
   }
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import EnvironmentPlugin from 'vite-plugin-environment';
+import dns from 'dns'
+
+// this will force the localhost dns to be "127.0.0.1" instead of "localhost"
+dns.setDefaultResultOrder('ipv4first')
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -9,4 +13,8 @@ export default defineConfig({
       'all'
     )
   ],
+  server: {
+    // this will force the port number to always be 5173
+    strictPort: true,
+  }
 })


### PR DESCRIPTION
## Description
Add configs to vite to enforce `127.0.0.1:5173` as the localhost url instead of `localhost:5173` and/or ports like `5174` etc

Source: https://vitejs.dev/config/server-options.html#server-strictport