### PR TITLE
Add Pausing/Unpausing timer functionality #17

### DIFF
--- a/src/components/Room.tsx
+++ b/src/components/Room.tsx
@@ -7,11 +7,13 @@ import formatTimestamp from "../helpers/formatTimestamp";
 import shareRoom from "../helpers/shareRoom";
 import startCountdown from "../helpers/startCountdown";
 import { roomName } from "../../common/common";
+import TimerControls from "./TimerControls";
 
 const Room = (): JSX.Element => {
 	const [isConnected, setIsConnected] = useState<boolean>(socket.connected);
 	const [timestamp, setTimestamp] = useState<number>(0);
 	const [usersInRoom, setUsersInRoom] = useState<number>(0);
+	const [isTimerPaused, setIsTimerPaused] = useState<boolean>(false);
 
 	/*
 	 * A store of the timer interval for a given client.
@@ -21,6 +23,10 @@ const Room = (): JSX.Element => {
 	 * 	timer: setInterval(),
 	 * }
 	 */
+
+	const pauseTimer = (): void => {
+		socket.emit("pauseCountdown", { roomName });
+	};
 
 	useEffect(() => {
 		const clientTimerStore: Record<
@@ -50,16 +56,15 @@ const Room = (): JSX.Element => {
 			secondsRemaining: number;
 			isPaused: boolean;
 		}): void => {
-			console.log("timerResponse", {
-				secondsRemaining,
-				isPaused,
-				clientTimerStore,
-			});
 			setTimestamp(secondsRemaining);
+
+			setIsTimerPaused(isPaused);
+
 			startCountdown({
 				durationInSeconds: secondsRemaining,
 				clientTimerStore,
 				setTimestamp,
+				isTimerPaused: isPaused,
 			});
 		};
 
@@ -77,10 +82,10 @@ const Room = (): JSX.Element => {
 	}, []);
 
 	useEffect(() => {
-		console.log({ timestamp });
+		console.log({ timestamp, isTimerPaused });
 		// update the document title, with roomName and timestamp
 		document.title = `${formatTimestamp(timestamp)}-${roomName}`;
-	}, [timestamp]);
+	}, [isTimerPaused, timestamp]);
 
 	useEffect(() => {
 		console.log("URL", window.location.href);
@@ -91,6 +96,11 @@ const Room = (): JSX.Element => {
 		<>
 			<ConnectionState isConnected={isConnected} />
 			<Timestamp timestamp={timestamp} />
+			<TimerControls
+				pauseTimer={pauseTimer}
+				isTimerPaused={isTimerPaused}
+			/>
+
 			<TimerForm />
 			<p>Users in room: {usersInRoom}</p>
 			<button type="button" onClick={shareRoom}>

--- a/src/components/Room.tsx
+++ b/src/components/Room.tsx
@@ -100,7 +100,6 @@ const Room = (): JSX.Element => {
 				pauseTimer={pauseTimer}
 				isTimerPaused={isTimerPaused}
 			/>
-
 			<TimerForm />
 			<p>Users in room: {usersInRoom}</p>
 			<button type="button" onClick={shareRoom}>

--- a/src/components/TimerControls.tsx
+++ b/src/components/TimerControls.tsx
@@ -6,12 +6,9 @@ const TimerControls = ({
 	isTimerPaused: boolean;
 }): JSX.Element => {
 	return (
-		<>
-			<p>Paused: {isTimerPaused}</p>
-			<button type="button" onClick={pauseTimer}>
-				Pause
-			</button>
-		</>
+		<button type="button" onClick={pauseTimer}>
+			{isTimerPaused ? "Resume" : "Pause"}
+		</button>
 	);
 };
 

--- a/src/components/TimerControls.tsx
+++ b/src/components/TimerControls.tsx
@@ -1,0 +1,18 @@
+const TimerControls = ({
+	pauseTimer,
+	isTimerPaused,
+}: {
+	pauseTimer: () => void;
+	isTimerPaused: boolean;
+}): JSX.Element => {
+	return (
+		<>
+			<p>Paused: {isTimerPaused}</p>
+			<button type="button" onClick={pauseTimer}>
+				Pause
+			</button>
+		</>
+	);
+};
+
+export default TimerControls;

--- a/src/helpers/startCountdown.ts
+++ b/src/helpers/startCountdown.ts
@@ -2,10 +2,12 @@ const startCountdown = ({
 	durationInSeconds,
 	clientTimerStore,
 	setTimestamp,
+	isTimerPaused,
 }: {
 	durationInSeconds: number;
 	clientTimerStore: Record<string, ReturnType<typeof setInterval>>;
 	setTimestamp: React.Dispatch<React.SetStateAction<number>>;
+	isTimerPaused: boolean;
 }): void => {
 	clearInterval(clientTimerStore.timer);
 
@@ -15,7 +17,9 @@ const startCountdown = ({
 		clearInterval(clientTimerStore.timer);
 	} else {
 		clientTimerStore.timer = setInterval(() => {
-			durationInSeconds--;
+			if (!isTimerPaused) {
+				durationInSeconds--;
+			}
 			setTimestamp(durationInSeconds);
 		}, 1000);
 	}


### PR DESCRIPTION
## Description
Added frontend logic to the pause/resume functionality.

This PR goes along with https://github.com/CommunityFocus/cf-backend/pull/47

Workflow:
1. When the user clicks on the pause button, there is a `pauseCountdown` socket event emitted to the server
2. The server listens for this, responds with `timerResponse` to all connected clients, and also sets the ` timerStore[roomname].isPaused` to the boolean value
3. When the client receives the `timerResponse` event from the server, the client will stop the existing timer, start a new timer, and will set `isPaused` to the boolean value
4. If client `isPaused` is true, the timer doesn't count down
5. There is also a setState `isTimerPaused` that will flip for any additional logic