### PR TITLE
add functionality to reset timer

### DIFF
--- a/src/components/Room.tsx
+++ b/src/components/Room.tsx
@@ -31,6 +31,10 @@ const Room = (): JSX.Element => {
 		socket.emit("pauseCountdown", { roomName });
 	};
 
+	const resetTimer = (): void => {
+		socket.emit("resetCountdown", { roomName });
+	};
+
 	useEffect(() => {
 		const clientTimerStore: Record<
 			string,
@@ -104,6 +108,7 @@ const Room = (): JSX.Element => {
 			<TimerControls
 				pauseTimer={pauseTimer}
 				isTimerPaused={isTimerPaused}
+				resetTimer={resetTimer}
 			/>
 			<TimerForm />
 			<p>Users in room: {usersInRoom}</p>

--- a/src/components/TimerControls.tsx
+++ b/src/components/TimerControls.tsx
@@ -1,14 +1,22 @@
 const TimerControls = ({
 	pauseTimer,
 	isTimerPaused,
+	resetTimer,
 }: {
 	pauseTimer: () => void;
 	isTimerPaused: boolean;
+	resetTimer: () => void;
 }): JSX.Element => {
 	return (
-		<button type="button" onClick={pauseTimer}>
-			{isTimerPaused ? "Resume" : "Pause"}
-		</button>
+		<>
+			<button type="button" onClick={pauseTimer}>
+				{isTimerPaused ? "Resume" : "Pause"}
+			</button>
+
+			<button type="button" onClick={resetTimer}>
+				Reset
+			</button>
+		</>
 	);
 };
 


### PR DESCRIPTION
## Description
Add reset timer functionality. The client will emit a `resetCountdown` event which the server will use to restart the countdown from the timerStore object.

To be closed together with: https://github.com/CommunityFocus/cf-backend/pull/49
Closes CommunityFocus/CommunityFocus/issues/16


