### PR TITLE
Fix Timer ticks down past 0 into negative values #41

### DIFF
--- a/src/helpers/startCountdown.test.ts
+++ b/src/helpers/startCountdown.test.ts
@@ -123,6 +123,20 @@ describe("startCountdown", () => {
 
 				expect(mockSetTimestamp).toHaveBeenCalledWith(9);
 			});
+			describe("when the timer ticks to 0", () => {
+				it("should clear the timer", () => {
+					startCountdown({
+						durationInSeconds,
+						clientTimerStore,
+						setTimestamp: mockSetTimestamp,
+						isTimerPaused: false,
+					});
+					jest.advanceTimersByTime(9000); // 9 seconds have passed. Should not have cleared the timer yet.
+					expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+					jest.advanceTimersByTime(1000); // 10 seconds have passed. Should have cleared the timer.
+					expect(clearIntervalSpy).toHaveBeenCalledTimes(2);
+				});
+			});
 
 			describe("when the timer is paused", () => {
 				it("should not decrement the durationInSeconds", () => {

--- a/src/helpers/startCountdown.test.ts
+++ b/src/helpers/startCountdown.test.ts
@@ -93,7 +93,7 @@ describe("startCountdown", () => {
 					isTimerPaused: false,
 				});
 
-				expect(clearIntervalSpy).toHaveBeenCalledTimes(2);
+				expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
 			});
 		});
 

--- a/src/helpers/startCountdown.ts
+++ b/src/helpers/startCountdown.ts
@@ -11,12 +11,14 @@ const startCountdown = ({
 
 	/* eslint-disable no-param-reassign */
 	if (durationInSeconds <= 0) {
-		setTimestamp(durationInSeconds);
-		clearInterval(clientTimerStore.timer);
+		setTimestamp(0);
 	} else {
 		clientTimerStore.timer = setInterval(() => {
 			durationInSeconds--;
 			setTimestamp(durationInSeconds);
+			if (durationInSeconds <= 0) {
+				clearInterval(clientTimerStore.timer);
+			}
 		}, 1000);
 	}
 };


### PR DESCRIPTION
## Description

Added an exit condition to `startCountdown()` to break out of a loop that would infinitely count negatives

Closes CommunityFocus/CommunityFocus/issues/41