### PR TITLE
Feat/user bubbles

### DIFF
--- a/common/types/types.ts
+++ b/common/types/types.ts
@@ -1,0 +1,9 @@
+export interface UsersInRoomArgs {
+	numUsers: number;
+	userList: string[];
+}
+
+export interface TimerResponseArgs {
+	secondsRemaining: number;
+	isPaused: boolean;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"react-router-dom": "^6.10.0",
+				"react-tooltip": "^5.13.1",
 				"socket.io-client": "^4.6.1",
 				"styled-components": "^5.3.10"
 			},
@@ -1097,6 +1098,19 @@
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@floating-ui/core": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.6.tgz",
+			"integrity": "sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg=="
+		},
+		"node_modules/@floating-ui/dom": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.9.tgz",
+			"integrity": "sha512-sosQxsqgxMNkV3C+3UqTS6LxP7isRLwX8WMepp843Rb3/b0Wz8+MdUkxJksByip3C2WwLugLHN1b4ibn//zKwQ==",
+			"dependencies": {
+				"@floating-ui/core": "^1.2.6"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
@@ -2972,6 +2986,11 @@
 			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
 			"integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
 			"dev": true
+		},
+		"node_modules/classnames": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+			"integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
 		},
 		"node_modules/cliui": {
 			"version": "8.0.1",
@@ -7170,6 +7189,19 @@
 				"react-dom": ">=16.8"
 			}
 		},
+		"node_modules/react-tooltip": {
+			"version": "5.13.1",
+			"resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.13.1.tgz",
+			"integrity": "sha512-9NstDFdjyy6cIH9zjeT70zXTHlW/TIGCOWQmhkAyqLFeQioLg1FXvb9ec7AxSpn0zyFUkFSLdFYxZRuewti3Aw==",
+			"dependencies": {
+				"@floating-ui/dom": "^1.0.0",
+				"classnames": "^2.3.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.14.0",
+				"react-dom": ">=16.14.0"
+			}
+		},
 		"node_modules/regenerator-runtime": {
 			"version": "0.13.11",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
@@ -9172,6 +9204,19 @@
 			"integrity": "sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==",
 			"dev": true
 		},
+		"@floating-ui/core": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.6.tgz",
+			"integrity": "sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg=="
+		},
+		"@floating-ui/dom": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.9.tgz",
+			"integrity": "sha512-sosQxsqgxMNkV3C+3UqTS6LxP7isRLwX8WMepp843Rb3/b0Wz8+MdUkxJksByip3C2WwLugLHN1b4ibn//zKwQ==",
+			"requires": {
+				"@floating-ui/core": "^1.2.6"
+			}
+		},
 		"@humanwhocodes/config-array": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
@@ -10541,6 +10586,11 @@
 			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
 			"integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
 			"dev": true
+		},
+		"classnames": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+			"integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
 		},
 		"cliui": {
 			"version": "8.0.1",
@@ -13632,6 +13682,15 @@
 			"requires": {
 				"@remix-run/router": "1.6.3",
 				"react-router": "6.12.1"
+			}
+		},
+		"react-tooltip": {
+			"version": "5.13.1",
+			"resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.13.1.tgz",
+			"integrity": "sha512-9NstDFdjyy6cIH9zjeT70zXTHlW/TIGCOWQmhkAyqLFeQioLg1FXvb9ec7AxSpn0zyFUkFSLdFYxZRuewti3Aw==",
+			"requires": {
+				"@floating-ui/dom": "^1.0.0",
+				"classnames": "^2.3.0"
 			}
 		},
 		"regenerator-runtime": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-router-dom": "^6.10.0",
+		"react-tooltip": "^5.13.1",
 		"socket.io-client": "^4.6.1",
 		"styled-components": "^5.3.10"
 	},

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { useEffect, useState } from "react";
 import socket from "./components/socket";
-import Room from "./components/Room.tsx";
-import DefaultRoom from "./components/DefaultRoom.tsx";
-import LandingPage from "./components/LandingPage.tsx";
+import Room from "./components/Room";
+import DefaultRoom from "./components/DefaultRoom";
+import LandingPage from "./components/LandingPage";
 
 const App = (): JSX.Element => {
 	const [globalUsersConnected, setGlobalUsersConnected] = useState<number>(0);

--- a/src/components/Room.tsx
+++ b/src/components/Room.tsx
@@ -12,6 +12,7 @@ import WelcomeMessage from "./WelcomeMessage";
 import TimerControls from "./TimerControls";
 import Footer from "./Footer";
 import LogoTitle from "./Logo/LogoTitle";
+import UserBubbles from "./UserBubbles/UserBubbles";
 
 const Room = (props: { globalUsersConnected: number }): JSX.Element => {
 	const { globalUsersConnected } = props;
@@ -19,6 +20,7 @@ const Room = (props: { globalUsersConnected: number }): JSX.Element => {
 	const [timestamp, setTimestamp] = useState<number>(0);
 	const [usersInRoom, setUsersInRoom] = useState<number>(0);
 	const [isTimerPaused, setIsTimerPaused] = useState<boolean>(false);
+	const [userListInRoom, setUserListInRoom] = useState<string[]>([]);
 
 	/*
 	 * A store of the timer interval for a given client.
@@ -114,6 +116,7 @@ const Room = (props: { globalUsersConnected: number }): JSX.Element => {
 			<button type="button" onClick={shareRoom}>
 				Share Room
 			</button>
+			<UserBubbles userListInRoom={userListInRoom} />
 			<Footer numUsers={globalUsersConnected} />
 		</>
 	);

--- a/src/components/Room.tsx
+++ b/src/components/Room.tsx
@@ -13,6 +13,7 @@ import TimerControls from "./TimerControls";
 import Footer from "./Footer";
 import LogoTitle from "./Logo/LogoTitle";
 import UserBubbles from "./UserBubbles/UserBubbles";
+import { TimerResponseArgs, UsersInRoomArgs } from "../../common/types/types";
 
 const Room = (props: { globalUsersConnected: number }): JSX.Element => {
 	const { globalUsersConnected } = props;
@@ -51,13 +52,7 @@ const Room = (props: { globalUsersConnected: number }): JSX.Element => {
 		setIsConnected(false);
 	};
 
-	const onUsersInRoom = ({
-		numUsers,
-		userList,
-	}: {
-		numUsers: number;
-		userList: string[];
-	}): void => {
+	const onUsersInRoom = ({ numUsers, userList }: UsersInRoomArgs): void => {
 		setUsersInRoom(numUsers);
 		setUserListInRoom(userList);
 	};
@@ -65,10 +60,7 @@ const Room = (props: { globalUsersConnected: number }): JSX.Element => {
 	const onTimerResponse = ({
 		secondsRemaining,
 		isPaused,
-	}: {
-		secondsRemaining: number;
-		isPaused: boolean;
-	}): void => {
+	}: TimerResponseArgs): void => {
 		setTimestamp(secondsRemaining);
 
 		setIsTimerPaused(isPaused);

--- a/src/components/Room.tsx
+++ b/src/components/Room.tsx
@@ -51,8 +51,15 @@ const Room = (props: { globalUsersConnected: number }): JSX.Element => {
 		setIsConnected(false);
 	};
 
-	const onUsersInRoom = (value: string): void => {
-		setUsersInRoom(parseInt(value));
+	const onUsersInRoom = ({
+		numUsers,
+		userList,
+	}: {
+		numUsers: number;
+		userList: string[];
+	}): void => {
+		setUsersInRoom(numUsers);
+		setUserListInRoom(userList);
 	};
 
 	const onTimerResponse = ({

--- a/src/components/UserBubbles/MultiUserBubble.tsx
+++ b/src/components/UserBubbles/MultiUserBubble.tsx
@@ -1,24 +1,22 @@
 import { Tooltip } from "react-tooltip";
 import { TooltipContainer, UserBubbleStyled } from "./UserBubble.styled";
 
-const UserBubble = (props: { user: string }) => {
-	const { user } = props;
+const MultiUserBubble = (props: { users: string[] }) => {
+	const { users } = props;
 	// first and last character of user name
 	return (
 		<TooltipContainer>
 			<UserBubbleStyled
 				$borderColor="brown"
-				data-tooltip-id="my-tooltip"
-				data-tooltip-content={user}
+				data-tooltip-id="my-tooltip-multilin"
+				data-tooltip-html={users.join("<br /><br />")}
 				data-tooltip-place="top"
 			>
-				<Tooltip id="my-tooltip" />
-				{user[0]
-					.toUpperCase()
-					.concat(user[user.length - 1].toUpperCase())}
+				<Tooltip id="my-tooltip-multilin" />
+				{`${users.length}+`}
 			</UserBubbleStyled>
 		</TooltipContainer>
 	);
 };
 
-export default UserBubble;
+export default MultiUserBubble;

--- a/src/components/UserBubbles/MultiUserBubble.tsx
+++ b/src/components/UserBubbles/MultiUserBubble.tsx
@@ -1,7 +1,7 @@
 import { Tooltip } from "react-tooltip";
 import { TooltipContainer, UserBubbleStyled } from "./UserBubble.styled";
 
-const MultiUserBubble = (props: { users: string[] }) => {
+const MultiUserBubble = (props: { users: string[] }): JSX.Element => {
 	const { users } = props;
 	return (
 		<TooltipContainer>

--- a/src/components/UserBubbles/MultiUserBubble.tsx
+++ b/src/components/UserBubbles/MultiUserBubble.tsx
@@ -3,13 +3,12 @@ import { TooltipContainer, UserBubbleStyled } from "./UserBubble.styled";
 
 const MultiUserBubble = (props: { users: string[] }) => {
 	const { users } = props;
-	// first and last character of user name
 	return (
 		<TooltipContainer>
 			<UserBubbleStyled
 				$borderColor="brown"
 				data-tooltip-id="my-tooltip-multilin"
-				data-tooltip-html={users.join("<br /><br />")}
+				data-tooltip-html={users.join("<br />")}
 				data-tooltip-place="top"
 			>
 				<Tooltip id="my-tooltip-multilin" />

--- a/src/components/UserBubbles/UserBubble.styled.tsx
+++ b/src/components/UserBubbles/UserBubble.styled.tsx
@@ -1,0 +1,27 @@
+import styled from "styled-components";
+
+export const UserBubbleStyled = styled.div<{ $borderColor?: string }>`
+	border-radius: 50%;
+	width: 30px;
+	height: 30px;
+	background-color: #393034;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	border: 4px solid ${(props): string => props.$borderColor || "#BF4F74"};
+	color: #fff;
+	font-size: 0.8rem;
+`;
+
+export const UserBubblesContainer = styled.div`
+	display: flex;
+	flex-direction: row;
+	justify-content: center;
+	align-items: center;
+	position: absolute;
+	bottom: 75px;
+	left: 0;
+	right: 0;
+	margin: auto;
+	gap: 5px;
+`;

--- a/src/components/UserBubbles/UserBubble.styled.tsx
+++ b/src/components/UserBubbles/UserBubble.styled.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-export const UserBubbleStyled = styled.div<{ $borderColor?: string }>`
+export const UserBubbleStyled = styled.a<{ $borderColor?: string }>`
 	border-radius: 50%;
 	width: 30px;
 	height: 30px;
@@ -24,4 +24,8 @@ export const UserBubblesContainer = styled.div`
 	right: 0;
 	margin: auto;
 	gap: 5px;
+`;
+
+export const TooltipContainer = styled.div`
+	border-radius: 50%;
 `;

--- a/src/components/UserBubbles/UserBubble.tsx
+++ b/src/components/UserBubbles/UserBubble.tsx
@@ -3,7 +3,6 @@ import { TooltipContainer, UserBubbleStyled } from "./UserBubble.styled";
 
 const UserBubble = (props: { user: string }) => {
 	const { user } = props;
-	// first and last character of user name
 	return (
 		<TooltipContainer>
 			<UserBubbleStyled

--- a/src/components/UserBubbles/UserBubble.tsx
+++ b/src/components/UserBubbles/UserBubble.tsx
@@ -1,7 +1,7 @@
 import { Tooltip } from "react-tooltip";
 import { TooltipContainer, UserBubbleStyled } from "./UserBubble.styled";
 
-const UserBubble = (props: { user: string }) => {
+const UserBubble = (props: { user: string }): JSX.Element => {
 	const { user } = props;
 	return (
 		<TooltipContainer>

--- a/src/components/UserBubbles/UserBubble.tsx
+++ b/src/components/UserBubbles/UserBubble.tsx
@@ -1,0 +1,10 @@
+const UserBubble = (props: { user: string }) => {
+	const { user } = props;
+	return (
+		<div>
+			<p>{user}</p>
+		</div>
+	);
+};
+
+export default UserBubble;

--- a/src/components/UserBubbles/UserBubble.tsx
+++ b/src/components/UserBubbles/UserBubble.tsx
@@ -1,9 +1,21 @@
+import { UserBubbleStyled } from "./UserBubble.styled";
+
+const randomColor = () => {
+	const letters = "0123456789ABCDEF";
+	let color = "#";
+	for (let i = 0; i < 6; i++) {
+		color += letters[Math.floor(Math.random() * 16)];
+	}
+	return color;
+};
+
 const UserBubble = (props: { user: string }) => {
 	const { user } = props;
+	// first and last character of user name
 	return (
-		<div>
-			<p>{user}</p>
-		</div>
+		<UserBubbleStyled $borderColor={randomColor()}>
+			{user[0].toUpperCase().concat(user[user.length - 1].toUpperCase())}
+		</UserBubbleStyled>
 	);
 };
 

--- a/src/components/UserBubbles/UserBubbles.tsx
+++ b/src/components/UserBubbles/UserBubbles.tsx
@@ -1,0 +1,15 @@
+import UserBubble from "./UserBubble";
+
+const UserBubbles = (props: { userListInRoom: string[] }): JSX.Element => {
+	const { userListInRoom } = props;
+
+	return (
+		<>
+			{userListInRoom.map((user: string) => (
+				<UserBubble user={user} />
+			))}
+		</>
+	);
+};
+
+export default UserBubbles;

--- a/src/components/UserBubbles/UserBubbles.tsx
+++ b/src/components/UserBubbles/UserBubbles.tsx
@@ -7,11 +7,6 @@ const UserBubbles = (props: { userListInRoom: string[] }): JSX.Element => {
 
 	return (
 		<UserBubblesContainer>
-			{/* {userListInRoom.map((user: string) => (
-				<UserBubble user={user} key={user} />
-			))} */}
-
-			{/* if there are less than 7, show all otherwise dont render the user bubble, but show an extra bubble with the number not shown as the user */}
 			{userListInRoom.length < 7 ? (
 				userListInRoom.map((user: string) => (
 					<UserBubble user={user} key={user} />

--- a/src/components/UserBubbles/UserBubbles.tsx
+++ b/src/components/UserBubbles/UserBubbles.tsx
@@ -1,14 +1,15 @@
 import UserBubble from "./UserBubble";
+import { UserBubblesContainer } from "./UserBubble.styled";
 
 const UserBubbles = (props: { userListInRoom: string[] }): JSX.Element => {
 	const { userListInRoom } = props;
 
 	return (
-		<>
+		<UserBubblesContainer>
 			{userListInRoom.map((user: string) => (
-				<UserBubble user={user} />
+				<UserBubble user={user} key={user} />
 			))}
-		</>
+		</UserBubblesContainer>
 	);
 };
 

--- a/src/components/UserBubbles/UserBubbles.tsx
+++ b/src/components/UserBubbles/UserBubbles.tsx
@@ -1,3 +1,4 @@
+import MultiUserBubble from "./MultiUserBubble";
 import UserBubble from "./UserBubble";
 import { UserBubblesContainer } from "./UserBubble.styled";
 
@@ -6,9 +7,23 @@ const UserBubbles = (props: { userListInRoom: string[] }): JSX.Element => {
 
 	return (
 		<UserBubblesContainer>
-			{userListInRoom.map((user: string) => (
+			{/* {userListInRoom.map((user: string) => (
 				<UserBubble user={user} key={user} />
-			))}
+			))} */}
+
+			{/* if there are less than 7, show all otherwise dont render the user bubble, but show an extra bubble with the number not shown as the user */}
+			{userListInRoom.length < 7 ? (
+				userListInRoom.map((user: string) => (
+					<UserBubble user={user} key={user} />
+				))
+			) : (
+				<>
+					{userListInRoom.slice(0, 6).map((user: string) => (
+						<UserBubble user={user} key={user} />
+					))}
+					<MultiUserBubble users={userListInRoom.slice(6)} />
+				</>
+			)}
 		</UserBubblesContainer>
 	);
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,6 @@
 		"noUnusedParameters": true,
 		"noFallthroughCasesInSwitch": true
 	},
-	"include": ["src", ".eslintrc.cjs"],
+	"include": ["src", ".eslintrc.cjs","common"],
 	"references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Description
Add user bubbles to show the list of users in the current room

To be closed together with: https://github.com/CommunityFocus/cf-backend/pull/52

Functionality:
1. When user joins, the user bubble gets added to all clients in that room
2. When user joins, the joined user gets a list of all connected clients
3. When user leaves, the user bubbles on all connected clients get updated to remove that user
4. if there are more than 6 clients, the 7th bubble is a concatenation that says +1 or +2 as required
5. Add tooltip to show the name of the user


Closes CommunityFocus/CommunityFocus/issues/61


1 user:
<img width="275" alt="image" src="https://github.com/CommunityFocus/cf-backend/assets/45009203/57e00386-46bc-4a9f-a223-4a4279bcb5e8">

6+ users:
<img width="525" alt="image" src="https://github.com/CommunityFocus/cf-backend/assets/45009203/586c4bc7-7729-48aa-8535-d1b8919e2464">

Tooltip:
<img width="589" alt="image" src="https://github.com/CommunityFocus/cf-frontend/assets/45009203/08e5880a-dfd7-4bb8-8b7a-492c90f413a2">

